### PR TITLE
New {{cursor}} placeholder for prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Wingman makes your prompts dynamic with support for placeholders.
 Current placeholders:
 
 - `{{selection}}` is replaced with the selected text.
+- `{{cursor}}` is replaced with text cursors current line.
+- `{{cursor:NUM_BEFORE:NUM_AFTER}}` is replaced with text cursors current line.
+  - e.g. `{{cursor:2:5}}` for lines curser pos - NUM_BEFORE to curser pos + NUM_AFTER
+- `{{cursor:2:5:'[MARKER]'}}` like previous but inserts [MARKER] at text cursor position.
 - `{{ft}}` is replaced with the VSCode language identifier (`go`, `typescript`)
 - `{{language}}` is replaced with a friendly language name (`Go`, `TypeScript`).
 - `{{file}}` is replaced with the contents of the active file.

--- a/webview/src/components/PromptForm.svelte
+++ b/webview/src/components/PromptForm.svelte
@@ -124,6 +124,14 @@
             in the active editor.
           </li>
           <li>
+            <code>{"{{"}cursor{"}}"}</code> - Replaced with the full text cursors current line
+            in the active editor.<br />
+            <code>{"{{"}cursor:BEFORE:AFTER{"}}"}</code> - Replaced with lines from
+            'text cursor line-BEFORE' to 'text cursor line+AFTER'<br />
+            - e.g. <code>{"{{"}cursor:2:5{"}}"}</code><br />
+            <code>{"{{"}cursor:2:5:'[MARKER]'{"}}"}</code> - Like previous but inserts [MARKER] at text cursor position.
+          </li>
+          <li>
             <code>{"{{"}:PARAM:VAL{"}}"}</code> - Set a completion parameter for the prompt when it is dispatched, e.g. <code>{"{{"}:top_k:4{"}}"}</code>.
           </li>
           <!-- <li>


### PR DESCRIPTION
Text manipulation around the text cursor
1. {{cursor}}
  - Returns the text cursors current line
2. {{cursor:2:5}}
  - Returns the text from... 'cursor line-2 at the start of the line' to 'cursor line+5 at the end of the line'
3. {{cursor:1:1:'[SOME_MARKER]'}}
  - Like 2. but inserts [SOME_MARKER] at text cursor position

Important:
- When text is selected the cursor position is always at the end of selection
- Only one {{cursor}} marker may be included in any prompt

Why: https://huggingface.co/stabilityai/stable-code-3b#run-with-fill-in-middle-fim-%E2%9A%A1%EF%B8%8F